### PR TITLE
Checks that "note" is not undefined before trying to create Uint8Array on Sign

### DIFF
--- a/packages/extension/src/background/messaging/task.ts
+++ b/packages/extension/src/background/messaging/task.ts
@@ -390,7 +390,7 @@ export class Task {
 
                         let txn = {...message.body.params};
 
-                        if ('note' in txn) {
+                        if ('note' in txn && txn.note !== undefined) {
                             txn.note = new Uint8Array(Buffer.from(txn.note));
                         }
 


### PR DESCRIPTION
Fixes bug that crashed the signing process when no note was included in the transaction.