### PR TITLE
Re-enabled checks for enabling submit button on account import

### DIFF
--- a/packages/ui/src/pages/ImportAccount.ts
+++ b/packages/ui/src/pages/ImportAccount.ts
@@ -26,7 +26,7 @@ const ImportAccount: FunctionalComponent = (props: any) => {
   const [authError, setAuthError] = useState<string>('');
   const [error, setError] = useState<string>('');
 
-  const matches = mnemonic.match(/\w+/g) || [];
+  const matches = mnemonic.trim().split(/[\s\t\r\n]+/) || [];
   const disabled = name.length === 0 || matches.length !== 25;
 
   const importAccount = (pwd: string) => {

--- a/packages/ui/src/pages/ImportAccount.ts
+++ b/packages/ui/src/pages/ImportAccount.ts
@@ -27,7 +27,7 @@ const ImportAccount: FunctionalComponent = (props: any) => {
   const [error, setError] = useState<string>('');
 
   const matches = mnemonic.trim().split(/[\s\t\r\n]+/) || [];
-  const disabled = name.length === 0 || matches.length !== 25;
+  const disabled = name.trim().length === 0 || matches.length !== 25;
 
   const importAccount = (pwd: string) => {
     const params = {

--- a/packages/ui/src/pages/ImportAccount.ts
+++ b/packages/ui/src/pages/ImportAccount.ts
@@ -26,14 +26,14 @@ const ImportAccount: FunctionalComponent = (props: any) => {
   const [authError, setAuthError] = useState<string>('');
   const [error, setError] = useState<string>('');
 
-  const disabled = false;
-  // const disabled = name.length === 0 || mnemonic.split(" ").length < 25;
+  const matches = mnemonic.match(/\w+/g) || [];
+  const disabled = name.length === 0 || matches.length !== 25;
 
   const importAccount = (pwd: string) => {
     const params = {
       passphrase: pwd,
-      mnemonic: mnemonic,
-      name: name,
+      mnemonic: matches.join(" "),
+      name: name.trim(),
       ledger: ledger
     };
     setLoading(true);


### PR DESCRIPTION
Changed the way the mnemonic is checked and sent. A regex match is now performed, matching just words. This enables separators between words to not only be spaces but also tabs and newlines.