### PR TITLE
Fix display for longer asset names

### DIFF
--- a/packages/ui/src/components/Account/AssetsList.ts
+++ b/packages/ui/src/components/Account/AssetsList.ts
@@ -19,20 +19,22 @@ const AssetPreview: FunctionalComponent = (props: any) => {
 
   return html`
     <div
-      class="py-2 px-4"
+      class="py-2 px-4 is-flex is-justify-content-space-between"
       data-asset-id="${asset['asset-id']}"
       data-asset-balance="${getAmount()}"
       style="border-top: 1px solid rgba(138, 159, 168, 0.2); cursor: pointer;"
       onClick=${() => setShowAsset(asset)}
     >
-      ${asset.name &&
-      asset.name.length > 0 &&
-      html`
-        ${asset.name}
-        <small class="has-text-grey-light"> ${asset['asset-id']}</small>
-      `}
-      ${(!asset.name || asset.name.length === 0) && html` ${asset['asset-id']} `}
-      <span style="float: right;">
+      <span style="max-width: 55%;">
+        ${asset.name &&
+        asset.name.length > 0 &&
+        html`
+          ${asset.name}
+          <small class="has-text-grey-light"> ${asset['asset-id']}</small>
+        `}
+        ${(!asset.name || asset.name.length === 0) && html` ${asset['asset-id']} `}
+      </span>
+      <span>
         <b>${getAmount()}</b>
         ${asset['unit-name'] &&
         asset['unit-name'].length > 0 &&


### PR DESCRIPTION
Previous:
![image](https://user-images.githubusercontent.com/5742610/153611381-acb21b9a-fceb-4f2e-8f2d-ccaf07c2245d.png)

New:
![image](https://user-images.githubusercontent.com/5742610/153611292-b5f48e98-89ba-4720-a357-a37d1c285b86.png)
