### PR TITLE
Updates to algorand.enable()

### DIFF
--- a/docs/dApp-integration.md
+++ b/docs/dApp-integration.md
@@ -582,9 +582,9 @@ Some of the following error codes may be returned when interacting with AlgoSign
 | 4000 | An unknown error occured. | N/A |
 | 4001 | The user rejected the signature request. | N/A |
 | 4100 | The requested operation and/or account has not been authorized by the user. | This is usually due to the connection between the dApp and the wallet becoming stale and the user [needing to reconnect](connection-issues.md). Otherwise, it may signal that you are trying to sign with private keys not found on AlgoSigner. | 
-| 4200 | The wallet does not support the requested operation. | N/A |
+| 4200 | The wallet does not support the requested operation. | Users need to have imported or created an account on AlgoSigner before connecting to dApps, as well as succesfully having configured any custom networks required. |
 | 4201 | The wallet does not support signing that many transactions at a time. | The max number of transactions per group is 16. For Ledger devices, they currently can't sign more than one transaction at the same time. |
-| 4202 | The wallet was not initialized properly beforehand. | Users need to have imported or created an account on AlgoSigner before connecting to dApps. |
+| 4202 | The wallet was not initialized properly beforehand. | The extension user has not authorized requests from this website. |
 | 4300 | The input provided is invalid. | AlgoSigner rejected some of the transactions due to invalid fields. |
 | 4400 | Some transactions were not sent properly. | Some, but not all of the transactions were able to be posted to the network. The IDs of the succesfully posted transactions as well as information on the failing ones are provided on the error.
 

--- a/docs/legacy-dApp-integration.md
+++ b/docs/legacy-dApp-integration.md
@@ -524,8 +524,8 @@ AlgoSigner.send({
   - A non-matching ledger name will result in a error:
     - The provided ledger is not supported (Code: 4200).
   - An empty request will result with an error:
-    - Ledger not provided. Please use a base ledger: [TestNet,MainNet] or an available custom one [{"name":"Theta","genesisId":"thetanet-v1.0"}].
-- Transaction requests will require a valid matching "genesisId", even for custom networks.
+    - Ledger not provided. Please use a base ledger: [TestNet,MainNet] or an available custom one [{"name":"Theta","genesisID":"thetanet-v1.0"}].
+- Transaction requests will require a valid matching "genesisID", even for custom networks.
 
 ## Signature Rejection Messages
 
@@ -536,9 +536,9 @@ AlgoSigner may return some of the following error codes when requesting signatur
 | 4000 | An unknown error occured. | N/A |
 | 4001 | The user rejected the signature request. | N/A |
 | 4100 | The requested operation and/or account has not been authorized by the user. | This is usually due to the connection between the dApp and the wallet becoming stale and the user [needing to reconnect](connection-issues.md). Otherwise, it may signal that you are trying to sign with private keys not found on AlgoSigner. | 
-| 4200 | The wallet does not support the requested operation. | N/A |
+| 4200 | The wallet does not support the requested operation. | Users need to have imported or created an account on AlgoSigner before connecting to dApps, as well as succesfully having configured any custom networks required. |
 | 4201 | The wallet does not support signing that many transactions at a time. | The max number of transactions per group is 16. For Ledger devices, they can't sign more than one transaction at the same time. |
-| 4202 | The wallet was not initialized properly beforehand. | Users need to have imported or created an account on AlgoSigner before connecting to dApps |
+| 4202 | The wallet was not initialized properly beforehand. | The extension user has not authorized requests from this website. |
 | 4300 | The input provided is invalid. | AlgoSigner rejected some of the transactions due to invalid fields. |
 
 Additional information, if available, would be provided in the `data` field of the error object.

--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -13,11 +13,8 @@ export class RequestError {
     'The extension user does not authorize the request.',
     4001
   );
-  static EnableRejected = (data: object): RequestError => new RequestError(
-    'The extension user does not authorize the request.',
-    4001,
-    data
-  );
+  static EnableRejected = (data: object): RequestError =>
+    new RequestError('The extension user does not authorize the request.', 4001, data);
   static NoMnemonicAvailable = (address: string): RequestError =>
     new RequestError(
       `The user does not possess the required private key to sign with for address: "${address}".`,
@@ -28,6 +25,12 @@ export class RequestError {
       `No matching account found on AlgoSigner for address "${address}" on network ${ledger}.`,
       4100
     );
+  static NoLedgerProvided = (base: string, injected: string): RequestError =>
+    new RequestError(
+      `Ledger not provided. Please use a base ledger: [${base}] or an available custom one ${injected}.`,
+      4200
+    );
+  static UnsupportedLedger = new RequestError('The provided ledger is not supported.', 4200);
   static UnsupportedNetwork = new RequestError('The provided network is not supported.', 4200);
   static PendingTransaction = new RequestError('Another query processing', 4201);
   static LedgerMultipleGroups = new RequestError(

--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -18,10 +18,6 @@ export class RequestError {
     4001,
     data
   );
-  static SiteNotAuthorizedByUser = new RequestError(
-    'The extension user has not authorized requests from this website.',
-    4100
-  );
   static NoMnemonicAvailable = (address: string): RequestError =>
     new RequestError(
       `The user does not possess the required private key to sign with for address: "${address}".`,
@@ -32,7 +28,7 @@ export class RequestError {
       `No matching account found on AlgoSigner for address "${address}" on network ${ledger}.`,
       4100
     );
-  static UnsupportedLedger = new RequestError('The provided ledger is not supported.', 4200);
+  static UnsupportedNetwork = new RequestError('The provided network is not supported.', 4200);
   static PendingTransaction = new RequestError('Another query processing', 4201);
   static LedgerMultipleGroups = new RequestError(
     'Ledger hardware device signing is only available for one transaction group at a time.',
@@ -44,6 +40,10 @@ export class RequestError {
   );
   static AlgoSignerNotInitialized = new RequestError(
     'AlgoSigner was not initialized properly beforehand.',
+    4200
+  );
+  static SiteNotAuthorizedByUser = new RequestError(
+    'The extension user has not authorized requests from this website.',
     4202
   );
   static InvalidFields = (data?: any): RequestError =>
@@ -129,8 +129,8 @@ export class RequestError {
     'All transactions provided in a same group need to have matching group IDs.',
     4300
   );
-  static NoDifferentLedgers = new RequestError(
-    'All transactions need to belong to the same ledger.',
+  static NoDifferentNetworks = new RequestError(
+    'All transactions need to belong to the same network.',
     4300
   );
   static PartiallySuccessfulPost = (successTxnIDs: string[], data: any): PostError =>

--- a/packages/common/src/types/ledgers.ts
+++ b/packages/common/src/types/ledgers.ts
@@ -1,7 +1,7 @@
 export class LedgerTemplate {
   name: string;
   readonly isEditable: boolean;
-  genesisId?: string;
+  genesisID?: string;
   genesisHash?: string;
   symbol?: string;
   algodUrl?: string;
@@ -14,7 +14,7 @@ export class LedgerTemplate {
 
   constructor({
     name,
-    genesisId,
+    genesisID,
     genesisHash,
     symbol,
     algodUrl,
@@ -22,7 +22,7 @@ export class LedgerTemplate {
     headers,
   }: {
     name: string;
-    genesisId?: string;
+    genesisID?: string;
     genesisHash?: string;
     symbol?: string;
     algodUrl?: string;
@@ -34,7 +34,7 @@ export class LedgerTemplate {
     }
 
     this.name = name;
-    this.genesisId = genesisId || 'mainnet-v1.0';
+    this.genesisID = genesisID || 'mainnet-v1.0';
     this.genesisHash = genesisHash;
     this.symbol = symbol;
     this.algodUrl = algodUrl;
@@ -49,12 +49,12 @@ export function getBaseSupportedLedgers(): Array<LedgerTemplate> {
   return [
     new LedgerTemplate({
       name: 'MainNet',
-      genesisId: 'mainnet-v1.0',
+      genesisID: 'mainnet-v1.0',
       genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
     }),
     new LedgerTemplate({
       name: 'TestNet',
-      genesisId: 'testnet-v1.0',
+      genesisID: 'testnet-v1.0',
       genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
     }),
   ];

--- a/packages/extension/src/background/config.ts
+++ b/packages/extension/src/background/config.ts
@@ -44,7 +44,7 @@ export class Settings {
     for (var i = 0; i < injectedNetworkKeys.length; i++) {
       injectedNetworks.push({
         name: this.backend_settings.InjectedNetworks[injectedNetworkKeys[i]].name,
-        genesisId: this.backend_settings.InjectedNetworks[injectedNetworkKeys[i]].genesisId,
+        genesisID: this.backend_settings.InjectedNetworks[injectedNetworkKeys[i]].genesisID,
       });
     }
 
@@ -86,9 +86,9 @@ export class Settings {
       }
     }
 
-    // Add the algod links defaulting the url to one based on the genesisId
+    // Add the algod links defaulting the url to one based on the genesisID
     let defaultUrl = 'https://algosigner.api.purestake.io/mainnet';
-    if (ledger.genesisId && ledger.genesisId.indexOf('testnet') > -1) {
+    if (ledger.genesisID && ledger.genesisID.indexOf('testnet') > -1) {
       defaultUrl = 'https://algosigner.api.purestake.io/testnet';
     }
 
@@ -125,10 +125,10 @@ export class Settings {
   }
 
   public static addInjectedNetwork(ledger: LedgerTemplate) {
-    // Initialize the injected network with the genesisId and a name that mimics the ledger for reference
+    // Initialize the injected network with the genesisID and a name that mimics the ledger for reference
     this.backend_settings.InjectedNetworks[ledger.name] = {
       name: ledger.name,
-      genesisId: ledger.genesisId || '',
+      genesisID: ledger.genesisID || '',
     };
 
     this.setInjectedHeaders(ledger);
@@ -149,7 +149,7 @@ export class Settings {
       this.deleteInjectedNetwork(previousName);
       this.backend_settings.InjectedNetworks[targetName] = {};
     }
-    this.backend_settings.InjectedNetworks[targetName].genesisId = updatedLedger.genesisId;
+    this.backend_settings.InjectedNetworks[targetName].genesisID = updatedLedger.genesisID;
     this.backend_settings.InjectedNetworks[targetName].symbol = updatedLedger.symbol;
     this.backend_settings.InjectedNetworks[targetName].genesisHash =
       updatedLedger.genesisHash;

--- a/packages/extension/src/background/messaging/internalMethods.test.ts
+++ b/packages/extension/src/background/messaging/internalMethods.test.ts
@@ -98,7 +98,7 @@ describe('wallet flow', () => {
         {
           algodUrl: undefined,
           genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
-          genesisId: 'mainnet-v1.0',
+          genesisID: 'mainnet-v1.0',
           headers: undefined,
           indexerUrl: undefined,
           isEditable: false,
@@ -108,7 +108,7 @@ describe('wallet flow', () => {
         {
           algodUrl: undefined,
           genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
-          genesisId: 'testnet-v1.0',
+          genesisID: 'testnet-v1.0',
           headers: undefined,
           indexerUrl: undefined,
           isEditable: false,
@@ -142,7 +142,7 @@ describe('wallet flow', () => {
         {
           algodUrl: undefined,
           genesisHash: 'wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
-          genesisId: 'mainnet-v1.0',
+          genesisID: 'mainnet-v1.0',
           headers: undefined,
           indexerUrl: undefined,
           isEditable: false,
@@ -152,7 +152,7 @@ describe('wallet flow', () => {
         {
           algodUrl: undefined,
           genesisHash: 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
-          genesisId: 'testnet-v1.0',
+          genesisID: 'testnet-v1.0',
           headers: undefined,
           indexerUrl: undefined,
           isEditable: false,

--- a/packages/extension/src/background/messaging/internalMethods.ts
+++ b/packages/extension/src/background/messaging/internalMethods.ts
@@ -16,7 +16,7 @@ import { ValidationStatus } from '../utils/validator';
 import {
   calculateEstimatedFee,
   getValidatedTxnWrap,
-  getLedgerFromGenesisId,
+  getLedgerFromGenesisID,
   getLedgerFromMixedGenesis,
 } from '../transaction/actions';
 import { BaseValidatedTxnWrap } from '../transaction/baseValidatedTxnWrap';
@@ -100,7 +100,7 @@ export class InternalMethods {
 
   // Checks if an account for the given address exists on AlgoSigner for a given ledger.
   public static checkAccountIsImported(genesisID: string, address: string): void {
-    const ledger: string = getLedgerFromGenesisId(genesisID);
+    const ledger: string = getLedgerFromGenesisID(genesisID);
     let found = false;
     for (let i = session.wallet[ledger].length - 1; i >= 0; i--) {
       if (session.wallet[ledger][i].address === address) {
@@ -500,7 +500,7 @@ export class InternalMethods {
           sendResponse({ message: message });
         } else if (session.txnRequest.source === 'ui') {
           // If this is an UI transaction then we need to submit to the network
-          const ledger = getLedgerFromGenesisId(decodedTxn.txn.genesisID);
+          const ledger = getLedgerFromGenesisID(decodedTxn.txn.genesisID);
 
           const algod = this.getAlgod(ledger);
           algod
@@ -1044,7 +1044,7 @@ export class InternalMethods {
       const targetName = previousName ? previousName : params['name'].toLowerCase();
       const addedLedger = new LedgerTemplate({
         name: params['name'],
-        genesisId: params['genesisId'],
+        genesisID: params['genesisID'],
         genesisHash: params['genesisHash'],
         symbol: params['symbol'],
         algodUrl: params['algodUrl'],
@@ -1070,7 +1070,7 @@ export class InternalMethods {
           if (!defaultLedgers.some((dledg) => dledg.uniqueName === matchingLedger.uniqueName)) {
             Settings.updateInjectedNetwork(addedLedger, previousName);
             matchingLedger.name = addedLedger.name;
-            matchingLedger.genesisId = addedLedger.genesisId;
+            matchingLedger.genesisID = addedLedger.genesisID;
             matchingLedger.symbol = addedLedger.symbol;
             matchingLedger.genesisHash = addedLedger.genesisHash;
             matchingLedger.algodUrl = addedLedger.algodUrl;

--- a/packages/extension/src/background/messaging/task.ts
+++ b/packages/extension/src/background/messaging/task.ts
@@ -485,10 +485,12 @@ export class Task {
         if (transactionWraps.length > 1) {
           if (
             !transactionWraps.every(
-              (wrap) => transactionWraps[0].transaction.genesisID === wrap.transaction.genesisID
+              (wrap) =>
+                transactionWraps[0].transaction.genesisID === wrap.transaction.genesisID ||
+                transactionWraps[0].transaction.genesisHash === wrap.transaction.genesisHash
             )
           ) {
-            throw RequestError.NoDifferentLedgers;
+            throw RequestError.NoDifferentNetworks;
           }
 
           if (!providedGroupId || !transactionWraps.every((wrap) => wrap.transaction.group)) {
@@ -648,7 +650,7 @@ export class Task {
             // This is because a dapp may request an id and hash from different ledgers
             if ((genesisID && genesisID !== ledgerTemplate.genesisId) 
             || (genesisHash && ledgerTemplate.genesisHash && genesisHash !== ledgerTemplate.genesisHash)) {
-              d.error = RequestError.UnsupportedLedger;
+              d.error = RequestError.UnsupportedNetwork;
               setTimeout(() => {
                 MessageApi.send(d);
               }, 500);
@@ -727,7 +729,7 @@ export class Task {
         
             // If we need a requested a ledger but don't have it, respond with an error
             if (walletAccounts === undefined) {
-              d.error = RequestError.UnsupportedLedger;
+              d.error = RequestError.UnsupportedNetwork;
 
               setTimeout(() => {
                 MessageApi.send(d);
@@ -1082,7 +1084,7 @@ export class Task {
           const accounts = session.wallet[d.body.params.ledger];
           // If we have requested a ledger but don't have it, respond with an error
           if (accounts === undefined) {
-            d.error = RequestError.UnsupportedLedger;
+            d.error = RequestError.UnsupportedNetwork;
             reject(d);
             return;
           }
@@ -1224,7 +1226,7 @@ export class Task {
 
               if (unlockedValue[ledger] === undefined) {
                 delete Task.requests[responseOriginTabID];
-                message.error = RequestError.UnsupportedLedger;
+                message.error = RequestError.UnsupportedNetwork;
                 MessageApi.send(message);
                 return;
               }

--- a/packages/extension/src/background/messaging/task.ts
+++ b/packages/extension/src/background/messaging/task.ts
@@ -7,7 +7,7 @@ import { Ledger } from '@algosigner/common/types';
 import { API } from './types';
 import {
   getValidatedTxnWrap,
-  getLedgerFromGenesisId,
+  getLedgerFromGenesisID,
   getLedgerFromMixedGenesis,
 } from '../transaction/actions';
 import { BaseValidatedTxnWrap } from '../transaction/baseValidatedTxnWrap';
@@ -46,7 +46,6 @@ export class Task {
     }
 
     // Validate the genesisID is the authorized one
-    // Note: The arc-0006 requires "genesisID" which matches the transaction, but we use "genesisId" internally in some places
     if (!Task.authorized_pool_details[origin] || !(Task.authorized_pool_details[origin]['genesisID'] === genesisID)) {
       return false;
     }
@@ -104,7 +103,7 @@ export class Task {
 
   public static getChainAuthAddress = async (transaction: any): Promise<string> => {
     // The ledger and address will be provided differently from UI and dapp
-    const ledger = transaction.ledger || getLedgerFromGenesisId(transaction.genesisID);
+    const ledger = transaction.ledger || getLedgerFromGenesisID(transaction.genesisID);
     const address = transaction.address || transaction.from;
 
     const conn = Settings.getBackendParams(ledger, API.Algod);
@@ -158,7 +157,7 @@ export class Task {
 
     if (transactionWrap.transaction['type'] === 'axfer') {
       const assetIndex = transactionWrap.transaction['assetIndex'];
-      const ledger = getLedgerFromGenesisId(transactionWrap.transaction['genesisID']);
+      const ledger = getLedgerFromGenesisID(transactionWrap.transaction['genesisID']);
       const conn = Settings.getBackendParams(ledger, API.Algod);
       const sendPath = `/v2/assets/${assetIndex}`;
       const fetchAssets: any = {
@@ -307,7 +306,7 @@ export class Task {
             if (!algosdk.isValidAddress(authAddr)) {
               throw RequestError.InvalidAuthAddress(authAddr);
             }
-            Task.checkAccountIsImportedAndAuthorized(ledger.name, ledger.genesisId, ledger.genesisHash, authAddr, request.origin);
+            Task.checkAccountIsImportedAndAuthorized(ledger.name, ledger.genesisID, ledger.genesisHash, authAddr, request.origin);
           }
 
           // If we have msigData, we validate the addresses and fetch the resulting msig address
@@ -372,7 +371,7 @@ export class Task {
                 // We make sure we have the available accounts for signing
                 signers.forEach((address) => {
                   try {
-                    Task.checkAccountIsImportedAndAuthorized(ledger.name, ledger.genesisId, ledger.genesisHash, address, request.origin);
+                    Task.checkAccountIsImportedAndAuthorized(ledger.name, ledger.genesisID, ledger.genesisHash, address, request.origin);
                   } catch (e) {
                     throw RequestError.CantMatchMsigSigners(e.message);
                   }
@@ -401,7 +400,7 @@ export class Task {
           } else {
             // There's no signers field, we validate the sender if there's no msig
             if (!msigData) {
-              Task.checkAccountIsImportedAndAuthorized(ledger.name, ledger.genesisId, ledger.genesisHash, wrap.transaction.from, request.origin);
+              Task.checkAccountIsImportedAndAuthorized(ledger.name, ledger.genesisID, ledger.genesisHash, wrap.transaction.from, request.origin);
             }
           }
 
@@ -628,7 +627,7 @@ export class Task {
           // Validate that the genesis id and hash if provided match the resulting one
           // This is because a dapp may request an id and hash from different ledgers
           if (
-            (genesisID && genesisID !== ledgerTemplate.genesisId) ||
+            (genesisID && genesisID !== ledgerTemplate.genesisID) ||
             (genesisHash &&
               ledgerTemplate.genesisHash &&
               genesisHash !== ledgerTemplate.genesisHash)
@@ -643,7 +642,7 @@ export class Task {
           // We've validated the ledger information
           // So we can set the ledger, genesisID, and genesisHash
           const ledger = ledgerTemplate.name;
-          genesisID = ledgerTemplate.genesisId;
+          genesisID = ledgerTemplate.genesisID;
           genesisHash = ledgerTemplate.genesisHash;
 
           // Then reflect those changes for the page
@@ -1128,7 +1127,7 @@ export class Task {
           const signErrors = [];
 
           try {
-            const ledger = getLedgerFromGenesisId(transactionObjs[0].genesisID);
+            const ledger = getLedgerFromGenesisID(transactionObjs[0].genesisID);
             const neededAccounts: Array<string> = [];
             walletTransactions.forEach((w, i) => {
               const msig = w.msig;

--- a/packages/extension/src/background/transaction/actions.ts
+++ b/packages/extension/src/background/transaction/actions.ts
@@ -125,33 +125,33 @@ export function getValidatedTxnWrap(
   return validatedTxnWrap;
 }
 
-export function getLedgerFromGenesisId(genesisId: string): string {
+export function getLedgerFromGenesisID(genesisID: string): string {
   // Default the ledger to mainnet
   const defaultLedger = 'MainNet';
 
   // Check Genesis ID for base supported ledgers first
   const defaultLedgers = getBaseSupportedLedgers();
-  let ledger = defaultLedgers.find((l) => genesisId === l['genesisId']);
+  let ledger = defaultLedgers.find((l) => genesisID === l['genesisID']);
   if (ledger !== undefined) {
     return ledger.name;
   }
   // Injected networks may have additional information, multiples, or additional checks
   // so we will check them separately
-  ledger = Settings.getCleansedInjectedNetworks().find((l) => genesisId === l['genesisId']);
+  ledger = Settings.getCleansedInjectedNetworks().find((l) => genesisID === l['genesisID']);
   if (ledger !== undefined) {
     return ledger.name;
   }
   return defaultLedger;
 }
 
-export function getLedgerFromMixedGenesis(genesisId: string, genesisHash?: string): LedgerTemplate {
+export function getLedgerFromMixedGenesis(genesisID: string, genesisHash?: string): LedgerTemplate {
   // Check Genesis Id and Hash for base supported ledgers first
   const defaultLedgers = getBaseSupportedLedgers();
   let ledger;
-  if (genesisId) {
-    ledger = defaultLedgers.find((l) => genesisId === l['genesisId']);
+  if (genesisID) {
+    ledger = defaultLedgers.find((l) => genesisID === l['genesisID']);
     if (ledger !== undefined) {
-      // Found genesisId, make sure the hash matches 
+      // Found genesisID, make sure the hash matches 
       if (!genesisHash || genesisHash === ledger.genesisHash) { 
         return ledger;
       }
@@ -159,7 +159,7 @@ export function getLedgerFromMixedGenesis(genesisId: string, genesisHash?: strin
     
     // Injected networks may have additional validations so we check them separately
     const injectedNetworks = Settings.getCleansedInjectedNetworks();
-    ledger = injectedNetworks.find((network) => network['genesisId'] === genesisId);
+    ledger = injectedNetworks.find((network) => network['genesisID'] === genesisID);
     if (ledger) {
       return ledger;
     }
@@ -170,7 +170,7 @@ export function getLedgerFromMixedGenesis(genesisId: string, genesisHash?: strin
     ledger = defaultLedgers.find((l) => genesisHash === l['genesisHash']);
     if (ledger !== undefined) {
       // Found genesisHash, make sure the id matches 
-      if (!genesisId || genesisId === ledger.genesisId) { 
+      if (!genesisID || genesisID === ledger.genesisID) { 
         return ledger;
       }
     }
@@ -203,7 +203,7 @@ export function calculateEstimatedFee(transactionWrap: BaseValidatedTxnWrap, par
         dummy replica transaction that's similar to what the SDK eventually sends
         For this we ignore all empty fields and shorten field names to 4 characters 
         so we use smaller field names like the SDK does
-        i.e.: the SDK uses 'gen' fpr 'genesisId', 'amt' for 'amount', etc
+        i.e.: the SDK uses 'gen' for 'genesisID', 'amt' for 'amount', etc
       */
       const dummyTransaction = {};
       Object.keys(transaction).map((key, index) => {

--- a/packages/extension/src/background/utils/validator.ts
+++ b/packages/extension/src/background/utils/validator.ts
@@ -217,8 +217,8 @@ export function Validate(field: any, value: any): ValidationResponse {
     // Genesis ID must be present and one of the approved values
     case 'genesisID':
       if (
-        getBaseSupportedLedgers().some((l) => value === l['genesisId']) ||
-        Settings.getCleansedInjectedNetworks().find((l) => value === l['genesisId'])
+        getBaseSupportedLedgers().some((l) => value === l['genesisID']) ||
+        Settings.getCleansedInjectedNetworks().find((l) => value === l['genesisID'])
       ) {
         return new ValidationResponse({ status: ValidationStatus.Valid });
       } else {

--- a/packages/test-project/package.json
+++ b/packages/test-project/package.json
@@ -6,10 +6,10 @@
   "description": "Repository for tests",
   "devDependencies": {
     "algosdk": "2.0.0",
-    "jest": "^28.1.0",
+    "jest": "^29.4.0",
     "jest-runner-groups": "^2.2.0",
     "puppeteer": "^13.7.0",
-    "ts-jest": "^28.0.2",
+    "ts-jest": "^29.0.5",
     "typescript": "^4.6.4"
   },
   "scripts": {

--- a/packages/test-project/tests/common/tests.js
+++ b/packages/test-project/tests/common/tests.js
@@ -188,7 +188,7 @@ function ConnectWithAlgorandObject(accounts) {
       })
     ).resolves.toMatchObject({
       message: expect.stringContaining('The extension user has not'),
-      code: 4100,
+      code: 4202,
     });
   });
 
@@ -315,7 +315,7 @@ function ConnectWithAlgoSignerObject() {
       })
     ).resolves.toMatchObject({
       message: expect.stringContaining('The extension user has not'),
-      code: 4100,
+      code: 4202,
     });
   });
 

--- a/packages/ui/src/components/LedgerDevice/LedgerHardwareSign.ts
+++ b/packages/ui/src/components/LedgerDevice/LedgerHardwareSign.ts
@@ -64,7 +64,7 @@ const LedgerHardwareSign: FunctionalComponent = () => {
           setTxn(txToSign);
 
           getBaseSupportedLedgers().forEach((l) => {
-            if (txToSign.transaction?.genesisID === l['genesisId']) {
+            if (txToSign.transaction?.genesisID === l['genesisID']) {
               const fetchedLedger = l['name'];
               setLedger(fetchedLedger);
               store.setLedger(fetchedLedger);

--- a/packages/ui/src/components/LedgerNetworkModify.ts
+++ b/packages/ui/src/components/LedgerNetworkModify.ts
@@ -19,7 +19,7 @@ const LedgerNetworkModify: FunctionalComponent = (props: any) => {
   const [authError, setAuthError] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(false);
   const [networkName, setNetworkName] = useState<string>(props.name || '');
-  const [networkId, setNetworkId] = useState<string>(props.genesisId || '');
+  const [networkID, setNetworkID] = useState<string>(props.genesisID || '');
   const [networkSymbol, setNetworkSymbol] = useState<string>(props.symbol || '');
   const [networkAlgodUrl, setNetworkAlgodUrl] = useState<string>(props.algodUrl || '');
   const [networkIndexerUrl, setNetworkIndexerUrl] = useState<string>(props.indexerUrl || '');
@@ -66,7 +66,7 @@ const LedgerNetworkModify: FunctionalComponent = (props: any) => {
     setError('');
     const params = {
       name: networkName,
-      genesisId: networkId,
+      genesisID: networkID,
       symbol: networkSymbol,
       algodUrl: networkAlgodUrl,
       indexerUrl: networkIndexerUrl,
@@ -97,7 +97,7 @@ const LedgerNetworkModify: FunctionalComponent = (props: any) => {
     const params = {
       name: networkName,
       previousName: previousName,
-      genesisId: networkId,
+      genesisID: networkID,
       symbol: networkSymbol,
       algodUrl: networkAlgodUrl,
       indexerUrl: networkIndexerUrl,
@@ -159,8 +159,8 @@ const LedgerNetworkModify: FunctionalComponent = (props: any) => {
             id="networkId"
             class="input"
             placeholder="mainnet-v1.0"
-            value=${networkId}
-            onInput=${(e) => setNetworkId(e.target.value)}
+            value=${networkID}
+            onInput=${(e) => setNetworkID(e.target.value)}
           />
           <label>Network Algod URL</label>
           <input

--- a/packages/ui/src/components/LedgerNetworksConfiguration.ts
+++ b/packages/ui/src/components/LedgerNetworksConfiguration.ts
@@ -92,7 +92,7 @@ const LedgerNetworksConfiguration: FunctionalComponent = (props: any) => {
                 }
               }}
               name=${activeLedgerTemplate.name}
-              genesisId=${activeLedgerTemplate.genesisId}
+              genesisID=${activeLedgerTemplate.genesisID}
               symbol=${activeLedgerTemplate.symbol}
               algodUrl=${activeLedgerTemplate.algodUrl}
               indexerUrl=${activeLedgerTemplate.indexerUrl}

--- a/packages/ui/src/pages/Enable.ts
+++ b/packages/ui/src/pages/Enable.ts
@@ -51,6 +51,7 @@ const Enable: FunctionalComponent = () => {
         restrictedLedgers = availableLedgers;
       }
       sessionLedgers = restrictedLedgers;
+      store.setLedger(restrictedLedgers[0].name);
     }
   });
 

--- a/packages/ui/src/pages/Enable.ts
+++ b/packages/ui/src/pages/Enable.ts
@@ -38,11 +38,11 @@ const Enable: FunctionalComponent = () => {
       let restrictedLedgers: any[] = [];
       if (networkSpecifiedType === 1) {
         restrictedLedgers.push(
-          availableLedgers.find((l) => l.genesisId === genesisID && l.genesisHash === genesisHash)
+          availableLedgers.find((l) => l.genesisID === genesisID && l.genesisHash === genesisHash)
         );
       } else if (networkSpecifiedType === 2) {
         restrictedLedgers.push(
-          availableLedgers.find((l) => l.genesisId === genesisID)
+          availableLedgers.find((l) => l.genesisID === genesisID)
         );
       } else {
         restrictedLedgers = availableLedgers;

--- a/packages/ui/src/pages/Enable.ts
+++ b/packages/ui/src/pages/Enable.ts
@@ -29,7 +29,6 @@ const Enable: FunctionalComponent = () => {
   const [genesisHash, setGenesisHash] = useState<any>('');
   const [networkSpecifiedType, setNetworkSpecifiedType] = useState<any>('');
   const [accounts, setPromptedAccounts] = useState<any>([]);
-  const [request, setRequest] = useState<any>({});
   const [active, setActive] = useState<boolean>(false);
   let sessionLedgers;
   let ddClass: string = 'dropdown';
@@ -42,16 +41,13 @@ const Enable: FunctionalComponent = () => {
           availableLedgers.find((l) => l.genesisId === genesisID && l.genesisHash === genesisHash)
         );
       } else if (networkSpecifiedType === 2) {
-        for (let i = 0; i < availableLedgers.length; i++) {
-          if (availableLedgers[i]['genesisId'] === genesisID) {
-            restrictedLedgers.push(availableLedgers[i]);
-          }
-        }
+        restrictedLedgers.push(
+          availableLedgers.find((l) => l.genesisId === genesisID)
+        );
       } else {
         restrictedLedgers = availableLedgers;
       }
       sessionLedgers = restrictedLedgers;
-      store.setLedger(restrictedLedgers[0].name);
     }
   });
 
@@ -73,29 +69,28 @@ const Enable: FunctionalComponent = () => {
     if (params.genesisHash) {
       setGenesisHash(params.genesisHash);
     }
-    if (params.ledger) {
-      // Ledger is added during EnableAuthorization to match with legacy ledger name and with GetEnableAccounts
-      store.setLedger(params.ledger);
-    }
     if (params.networkSpecifiedType) {
       setNetworkSpecifiedType(params.networkSpecifiedType);
     }
   };
 
-  const setLedger = (ledger) => {
-    store.setLedger(ledger);
-    flip();
-
-    // Set the new ledger to be loaded
-    request.body.params['ledger'] = ledger;
-
-    sendMessage(JsonRpcMethod.GetEnableAccounts, request.body.params, function (response) {
-      if (response.error) {
-        console.error(response.error);
-      } else {
-        setDetails(response);
+  const setLedger = (ledger: string) => {
+    if (ledger && store.savedRequest?.body) {
+      store.setLedger(ledger);
+  
+      // Set the new ledger to be loaded
+      const params = {
+        ...store.savedRequest.body.params,
+        ledger: ledger,
       }
-    });
+      sendMessage(JsonRpcMethod.GetEnableAccounts, params, function (response) {
+        if (response.error) {
+          console.error(response.error);
+        } else {
+          setDetails(response);
+        }
+      });
+    }
   };
 
   useEffect(() => {
@@ -103,17 +98,18 @@ const Enable: FunctionalComponent = () => {
     chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       if (request.body.method == JsonRpcMethod.EnableAuthorization) {
         // Set the request in the store with origin so we can respond later
-        setRequest(request);
         store.saveRequest(request);
         responseOriginTabID = request.originTabID;
-
-        // Check for existence of the params and set page values
-        setDetails(request.body.params);
+        setLedger(request?.body?.params?.ledger);
       }
     });
     window.addEventListener('beforeunload', deny);
     return () => window.removeEventListener('beforeunload', deny);
   }, []);
+
+  useEffect(() => {
+    setLedger(store.savedRequest?.body?.params?.ledger);
+  }, [store.savedRequest]);
 
   const grant = () => {
     window.removeEventListener('beforeunload', deny);
@@ -143,18 +139,18 @@ const Enable: FunctionalComponent = () => {
         <div style="flex: 1">
           <section class="hero">
             <div class="hero-body py-5">
-              ${request.favIconUrl &&
-              html` <img src=${request.favIconUrl} width="48" style="float:left" /> `}
+              ${store.savedRequest?.favIconUrl &&
+              html` <img src=${store.savedRequest.favIconUrl} width="48" style="float:left" /> `}
               <h1 class="title is-size-4" style="margin-left: 58px;">
                 Access requested to your
-                wallet${request.originTitle && html` from ${request.originTitle}`}
+                wallet${store.savedRequest?.originTitle && html` from ${store.savedRequest?.originTitle}`}
               </h1>
             </div>
           </section>
           <section class="px-5 py-0">
             <h3
               >Select the accounts to
-              share${request.originTitle && html` with ${request.originTitle}`}.
+              share${store.savedRequest?.originTitle && html` with ${store.savedRequest?.originTitle}`}.
               <b> Bolded</b> accounts are required by the dApp.</h3
             >
             <div class="is-flex is-align-items-baseline my-3">
@@ -189,7 +185,7 @@ const Enable: FunctionalComponent = () => {
                           html`
                             <a
                               id="select${availableLedger.name}"
-                              onClick=${() => setLedger(availableLedger.name)}
+                              onClick=${() => { setLedger(availableLedger.name); flip(); }}
                               class="dropdown-item"
                             >
                               ${availableLedger.name}

--- a/packages/ui/src/pages/Login.ts
+++ b/packages/ui/src/pages/Login.ts
@@ -42,13 +42,9 @@ const Login: FunctionalComponent = (props: any) => {
         store.setAvailableLedgers(response.availableLedgers);
         store.updateWallet(response.wallet, () => {
           store.setLedger(response.ledger);
-          if (redirect.length > 0 && redirect === 'close') { 
-            window.close();
-          }
-          else if (redirect.length > 0) { 
+          if (redirect.length > 0) { 
             route(`/${redirect}`);
-          }
-          else { 
+          } else { 
             route('/wallet');
           }
         });

--- a/packages/ui/src/pages/SignWalletTransaction.ts
+++ b/packages/ui/src/pages/SignWalletTransaction.ts
@@ -183,7 +183,7 @@ const SignWalletTransaction: FunctionalComponent = () => {
       // Search for ledger and find accounts
       let txLedger;
       getBaseSupportedLedgers().forEach((l) => {
-        if (transactionWraps[0].transaction.genesisID === l['genesisId']) {
+        if (transactionWraps[0].transaction.genesisID === l['genesisID']) {
           txLedger = l['name'];
           setLedger(txLedger);
           findAccountNames(txLedger);
@@ -197,7 +197,7 @@ const SignWalletTransaction: FunctionalComponent = () => {
           if (!availableLedgers.error) {
             sessionLedgers = availableLedgers;
             sessionLedgers.forEach((l) => {
-              if (transactionWraps[0].transaction.genesisID === l['genesisId']) {
+              if (transactionWraps[0].transaction.genesisID === l['genesisID']) {
                 txLedger = l['name'];
               }
             });


### PR DESCRIPTION
- Updates the way enable calls behave when the user is logged out of the wallet
- Fixes some account checking issues
- Unifies `genesisId` with `genesisID`, it was a remnant of v1 and was now being only used internally
- Update several error codes and messages, as well as adding new errors to differentiate certain use cases
- Updated documentation for the previous change